### PR TITLE
feat: refactor to use common identifier obj

### DIFF
--- a/client/enum/bodyFormat.js
+++ b/client/enum/bodyFormat.js
@@ -1,0 +1,11 @@
+const responseText = require("./responseText");
+
+const bodyFormat = {
+  NONE: {id: "NONE", text: responseText.NONE}, 
+  LINE: {id: "LINE", text: responseText.LINE}, 
+  SIGNATURE: {id: "SIGNATURE", text: responseText.LINE}, 
+  BLOCK: {id: "BLOCK", text: responseText.BLOCK}, 
+  VALUE: {id: "VALUE", text: responseText.LINE}
+}
+
+module.exports = bodyFormat;

--- a/client/enum/matchType.js
+++ b/client/enum/matchType.js
@@ -1,30 +1,49 @@
+const bodyFormat = require("./BodyFormat");
+
 const matchType = {
-  UNKNOWN: {id: 'UNKNOWN'},
-  LOCAL_VAR: {id: 'LOCAL_VAR', definitionFiles: ["rs2"], definitionFormat: '$NAME'},
-  GLOBAL_VAR: {id: 'GLOBAL_VAR', definitionFiles: ["varp", "varn", "vars"], definitionFormat: '[NAME]', previewDeclaration: true},
-  CONSTANT: {id: 'CONSTANT', definitionFiles: ["constant"], definitionFormat: '^NAME', previewDeclaration: true},
-  LABEL: {id: 'LABEL', types: ["label"], definitionFiles: ["rs2"], definitionFormat: '[label,NAME]', previewDeclaration: true},
-  PROC: {id: 'PROC', types: ["proc"], definitionFiles: ["rs2"], definitionFormat: '[proc,NAME]', previewDeclaration: true},
-  TIMER: {id: 'TIMER', types: ["timer"], definitionFiles: ["rs2"], definitionFormat: '[timer,NAME]'},
-  SOFTTIMER: {id: 'SOFTTIMER', types: ["softtimer"], definitionFiles: ["rs2"], definitionFormat: '[softtimer,NAME]'},
-  QUEUE: {id: 'QUEUE', types: ["queue"], definitionFiles: ["rs2"], definitionFormat: '[queue,NAME]', previewDeclaration: true},
-  SEQ: {id: 'SEQ', types: ["seq"], definitionFiles: ["seq"], definitionFormat: '[NAME]'},
-  SPOTANIM: {id: 'SPOTANIM', types: ["spotanim"], definitionFiles: ["spotanim"], definitionFormat: '[NAME]'},
-  HUNT: {id: 'HUNT', types: ["hunt"], definitionFiles: ["hunt"], definitionFormat: '[NAME]'},
-  LOC: {id: 'LOC', types: ["loc"], definitionFiles: ["loc"], definitionFormat: '[NAME]'},
-  NPC: {id: 'NPC', types: ["npc"], definitionFiles: ["npc"], definitionFormat: '[NAME]'},
-  OBJ: {id: 'OBJ', types: ["namedobj", "obj"], definitionFiles: ["obj"], definitionFormat: '[NAME]'},
-  INV: {id: 'INV', types: ["inv"], definitionFiles: ["inv"], definitionFormat: '[NAME]'},
-  ENUM: {id: 'ENUM', types: ["enum"], definitionFiles: ["enum"], definitionFormat: '[NAME]', previewDeclaration: true},
-  DBROW: {id: 'DBROW', types: ["dbrow"], definitionFiles: ["dbrow"], definitionFormat: '[NAME]', previewDeclaration: true},
-  DBTABLE: {id: 'DBTABLE', types: ["dbtable"], definitionFiles: ["dbtable"], definitionFormat: '[NAME]', previewDeclaration: true},
-  INTERFACE: {id: 'INTERFACE', types: ["interface"], definitionFiles: ["pack"], definitionFormat: 'NAME'},
-  PARAM: {id: 'PARAM', types: ["param"], definitionFiles: ["param"], definitionFormat: '[NAME]', previewDeclaration: true},
-  COMMAND: {id: 'COMMAND', definitionFiles: ["rs2"], definitionFormat: '[command,NAME]'},
-  SYNTH: {id: 'SOUND_SYNTH', types: ["synth"], definitionFiles: ["synth"], definitionFormat: 'NAME'},
-  WALKTRIGGER: {id: 'WALKTRIGGER', types: ["walktrigger"], definitionFiles: ["rs2"], definitionFormat: '[walktrigger,NAME]'},
-  IDK: {id: 'IDK', types: ["idk", "idkit"], definitionFiles: ["idk"], definitionFormat: '[NAME]'},
-  MESANIM: {id: 'MESANIM', types: ["mesanim"], definitionFiles: ["mesanim"], definitionFormat: '[NAME]'},
+  UNKNOWN: build('UNKNOWN'),
+  LOCAL_VAR: build('LOCAL_VAR', [], null, ["rs2"], '$NAME'),
+  GLOBAL_VAR: build('GLOBAL_VAR', [], null, ["varp", "varn", "vars"], '[NAME]', bodyFormat.BLOCK, bodyFormat.NONE),
+  CONSTANT: build('CONSTANT', [], null, ["constant"], '^NAME', bodyFormat.VALUE, bodyFormat.NONE),
+  LABEL: build('LABEL', ["label"], null, ["rs2"], '[label,NAME]', bodyFormat.SIGNATURE, bodyFormat.SIGNATURE),
+  PROC: build('PROC', ["proc"], null, ["rs2"], '[proc,NAME]', bodyFormat.SIGNATURE, bodyFormat.SIGNATURE),
+  TIMER: build('TIMER', ["timer"], null, ["rs2"], '[timer,NAME]', bodyFormat.NONE, bodyFormat.NONE),
+  SOFTTIMER: build('SOFTTIMER', ["softtimer"], null, ["rs2"], '[softtimer,NAME]', bodyFormat.NONE, bodyFormat.NONE),
+  QUEUE: build('QUEUE', ["queue"], null, ["rs2"], '[queue,NAME]', bodyFormat.SIGNATURE, bodyFormat.SIGNATURE),
+  SEQ: build('SEQ', ["seq"], null, ["seq"], '[NAME]', bodyFormat.NONE, bodyFormat.NONE),
+  SPOTANIM: build('SPOTANIM', ["spotanim"], null, ["spotanim"], '[NAME]', bodyFormat.NONE, bodyFormat.NONE),
+  HUNT: build('HUNT', ["hunt"], null, ["hunt"], '[NAME]', bodyFormat.NONE, bodyFormat.NONE),
+  LOC: build('LOC', ["loc"], null, ["loc"], '[NAME]', bodyFormat.NONE, bodyFormat.NONE),
+  NPC: build('NPC', ["npc"], null, ["npc"], '[NAME]', bodyFormat.NONE, bodyFormat.NONE),
+  OBJ: build('OBJ', ["namedobj", "obj"], null, ["obj"], '[NAME]', bodyFormat.NONE, bodyFormat.NONE),
+  INV: build('INV', ["inv"], null, ["inv"], '[NAME]', bodyFormat.NONE, bodyFormat.NONE),
+  ENUM: build('ENUM', ["enum"], null, ["enum"], '[NAME]', bodyFormat.BLOCK, bodyFormat.NONE),
+  DBROW: build('DBROW', ["dbrow"], null, ["dbrow"], '[NAME]', bodyFormat.BLOCK, bodyFormat.NONE),
+  DBTABLE: build('DBTABLE', ["dbtable"], null, ["dbtable"], '[NAME]', bodyFormat.BLOCK, bodyFormat.NONE),
+  INTERFACE: build('INTERFACE', ["interface"], "interface.pack", ["pack"], 'NAME', bodyFormat.NONE, bodyFormat.NONE),
+  PARAM: build('PARAM', ["param"], null, ["param"], '[NAME]', bodyFormat.BLOCK, bodyFormat.NONE),
+  COMMAND: build('COMMAND', [], "engine.rs2", ["rs2"], '[command,NAME]', bodyFormat.SIGNATURE, bodyFormat.NONE),
+  SYNTH: build('SOUND_SYNTH', ["synth"], "sound.pack", ["synth"], 'NAME', bodyFormat.NONE, bodyFormat.NONE),
+  WALKTRIGGER: build('WALKTRIGGER', ["walktrigger"], null, ["rs2"], '[walktrigger,NAME]', bodyFormat.NONE, bodyFormat.NONE),
+  IDK: build('IDK', ["idk", "idkit"], null, ["idk"], '[NAME]', bodyFormat.BLOCK, bodyFormat.NONE),
+  MESANIM: build('MESANIM', ["mesanim"], null, ["mesanim"], '[NAME]', bodyFormat.NONE, bodyFormat.NONE),
 };
+
+function build(id, types, file, fileTypes, format, refBodyFormat = bodyFormat.NONE, decBodyFormat = bodyFormat.NONE) {
+  return {
+    id: id,
+    types: types, 
+    definitionFile: file,
+    definitionFiles: fileTypes,
+    definitionFormat: format,
+    referenceBodyFormat: refBodyFormat,
+    declarationBodyFormat: decBodyFormat,
+    responseText: determineRequiredResponseText(refBodyFormat, decBodyFormat)
+  }
+}
+
+function determineRequiredResponseText(bodyFormat1, bodyFormat2) {
+  return Math.max(bodyFormat1.text, bodyFormat2.text);
+}
 
 module.exports = matchType;

--- a/client/enum/responseText.js
+++ b/client/enum/responseText.js
@@ -1,0 +1,5 @@
+const responseText = {
+  NONE: 0, LINE: 1, BLOCK: 2, FULL: 3
+}
+
+module.exports = responseText;

--- a/client/provider/hover/hoverProvider.js
+++ b/client/provider/hover/hoverProvider.js
@@ -75,8 +75,8 @@ function buildCommandHoverText(word, match, content) {
 
 async function buildSignatureHoverText(word, match, uri, content) {
   const identifier = await getIdentifier(word, match, uri);
-  appendTitle(word, match, content);
   if (identifier) {
+    appendTitle(word, match, content);
     appendSignature(identifier, content);
   }
 }
@@ -87,15 +87,13 @@ async function buildBlockHoverText(word, match, uri, content) {
     const typeOverride = (match.id === matchType.GLOBAL_VAR.id) ? identifier.value : null; // differentiate global var type
     appendTitle(word, match, content, typeOverride); 
     appendBlock(identifier, content);
-  } else {
-    appendTitle(word, match, content);
   }
 }
 
 async function buildValueHoverText(word, match, uri, content) {
   const identifier = await getIdentifier(word, match, uri);
-  appendTitle(word, match, content); 
   if (identifier) {
+    appendTitle(word, match, content); 
     appendValue(identifier, content);
   }
 }

--- a/client/provider/hover/hoverProvider.js
+++ b/client/provider/hover/hoverProvider.js
@@ -37,7 +37,8 @@ const hoverProvider = function(context) {
       }
 
       if (prevChar === ',' && word.startsWith('_')) {
-        const infoText = `the underscore indicates this refers to any ${match.id.toLowerCase()} with <b>category=${word.substring(1)}</b>`;
+        const searchableString = createSearchableString(`category=${word.substring(1)}`, `category=${word.substring(1)}`, searchUtils.getInclusionFiles(match));
+        const infoText = `the underscore indicates this refers to any ${match.id.toLowerCase()} with <b>${searchableString}</b>`;
         appendBodyWithLabel(infoText, "info", content);
       }
 
@@ -145,6 +146,11 @@ function appendBody(text, content) {
 
 function appendBodyWithLabel(text, label, content) {
   appendBody(`<b>${label}:</b> <i>${text}</i>`, content);
+}
+
+function createSearchableString(linkableText, query, filesToInclude, isRegex=false) {
+  const searchOptions = JSON.stringify({ query: query, filesToInclude: filesToInclude, isRegex: isRegex});
+  return `[${linkableText}](${vscode.Uri.parse(`command:workbench.action.findInFiles?${encodeURIComponent(searchOptions)}`)})`;
 }
 
 async function getIdentifier(word, match, uri) {

--- a/client/provider/hover/hoverProvider.js
+++ b/client/provider/hover/hoverProvider.js
@@ -11,7 +11,7 @@ const identifierSvc = require('../../resource/identifierSvc');
 const hoverProvider = function(context) {
   return {
     async provideHover(document, position, token) {
-      const { word, fileType, match } = await matchUtils.matchWord(document, position);
+      const { word, fileType, prevChar, match } = await matchUtils.matchWord(document, position);
       if (!word) {
         return null;
       }
@@ -34,6 +34,11 @@ const hoverProvider = function(context) {
             case bodyFormat.VALUE: await buildValueHoverText(word, match, uri, content); break;
             default: appendTitle(word, match, content, (match.id === matchType.GLOBAL_VAR.id) ? fileType : null);
           }
+      }
+
+      if (prevChar === ',' && word.startsWith('_')) {
+        const infoText = `the underscore indicates this refers to any ${match.id.toLowerCase()} with <b>category=${word.substring(1)}</b>`;
+        appendBodyWithLabel(infoText, "info", content);
       }
 
       if (content.value.length) {

--- a/client/provider/hover/hoverProvider.js
+++ b/client/provider/hover/hoverProvider.js
@@ -5,15 +5,18 @@ const stringUtils = require('../../utils/stringUtils');
 const searchUtils = require('../../utils/searchUtils');
 const matchType = require('../../enum/MatchType');
 const { commands } = require('../../resource/engineCommands');
+const bodyFormat = require('../../enum/BodyFormat');
+const identifierSvc = require('../../resource/identifierSvc');
 
 const hoverProvider = function(context) {
   return {
     async provideHover(document, position, token) {
-      const { word, lineText, fileType, match } = matchUtils.matchWord(document, position);
+      const { word, fileType, match } = await matchUtils.matchWord(document, position);
       if (!word) {
         return null;
       }
 
+      const uri = document.uri;
       const content = new vscode.MarkdownString();
       content.supportHtml = true;
       content.isTrusted = true;
@@ -21,26 +24,16 @@ const hoverProvider = function(context) {
       content.baseUri = vscode.Uri.file(path.join(context.extensionPath, 'icons', path.sep)); 
 
       switch (match.id) {
-        case matchType.LOCAL_VAR.id: 
-          buildLocalVarHoverText(document, position, word, match, content); 
-          break;
-        case matchType.CONSTANT.id: 
-          await buildConstantHoverText(word, match, content); 
-          break;
-        case matchType.GLOBAL_VAR.id: 
-          await buildGlobalVarHoverText(word, match, fileType, content); 
-          break;
-        case matchType.PROC.id: case matchType.LABEL.id: case matchType.QUEUE.id: case matchType.TIMER.id: case matchType.SOFTTIMER.id:
-          await buildBlockHoverText(word, match, lineText, content); 
-          break;
-        case matchType.ENUM.id:
-          await buildEnumHoverText(word, match, content);
-          break;
-        case matchType.COMMAND.id:
-          buildCommandHoverText(word, match, content);
-          break;
-        default: 
-          await buildDefaultHoverText(word, match, content);
+        case matchType.LOCAL_VAR.id: buildLocalVarHoverText(document, position, word, match, content); break;
+        case matchType.COMMAND.id: buildCommandHoverText(word, match, content); break;
+        default:
+          const format = (match.declaration) ? match.declarationBodyFormat : match.referenceBodyFormat;
+          switch(format) {
+            case bodyFormat.SIGNATURE: await buildSignatureHoverText(word, match, uri, content); break;
+            case bodyFormat.BLOCK: await buildBlockHoverText(word, match, uri, content); break;
+            case bodyFormat.VALUE: await buildValueHoverText(word, match, uri, content); break;
+            default: appendTitle(word, match, content, (match.id === matchType.GLOBAL_VAR.id) ? fileType : null);
+          }
       }
 
       if (content.value.length) {
@@ -51,74 +44,17 @@ const hoverProvider = function(context) {
 }
 
 function buildLocalVarHoverText(document, position, word, match, content) {
-  appendMarkdown(content, "LOCAL_VAR", word, "rs2");
+  appendTitle(word, match, content);
   if (match.declaration === false) {
     const fileText = document.getText(new vscode.Range(new vscode.Position(0, 0), position));
-    const match = searchUtils.searchLocalVar(fileText, word);
+    const match = searchUtils.findLocalVar(fileText, word);
     const isDef = fileText.substring(Math.max(match.index - 4, 0), match.index) === "def_";
     if (isDef) {
       const line = stringUtils.getLineText(fileText.substring(match.index - 4));;
-      appendMarkdownBody(content, line.substring(0, line.indexOf(";")), true);
+      appendBody(line.substring(0, line.indexOf(";")), content);
     } else {
       const lineText = stringUtils.getLineText(fileText.substring(match.index));
-      appendMarkdownBody(content, `input parameter (${lineText.substring(0, lineText.indexOf(word) + word.length)})`, true);
-    }
-  }
-}
-
-async function buildConstantHoverText(word, match, content) {
-  if (match.declaration) {
-    appendMarkdown(content, "constant", word, "constant");
-  } else {
-    const results = await searchUtils.searchFiles(`^${word}`, ["constant"], 0, 1);
-    if (results && results.length > 0) {
-      appendMarkdown(content, "constant", results[0].text, "constant");
-    }
-  }
-}
-
-async function buildGlobalVarHoverText(word, match, fileType, content) {
-  let results;
-  const pattern = match.definitionFormat.replace("NAME", word);
-  if (match.declaration === false && match.previewDeclaration === true) {
-    results = await searchUtils.searchFiles(pattern, match.definitionFiles, 0, 1, searchUtils.textResult.remaining);
-    fileType = results.length > 0 ? results[0].location.uri.path.split(/[#?]/)[0].split('.').pop().trim() : 'varp';
-  }
-  appendMarkdown(content, fileType, pattern, fileType);
-  if (results && results.length > 0) {
-    appendBodyUntilEmptyLine(content, results[0].text, true, 1);
-  }
-}
-
-async function buildBlockHoverText(word, match, lineText, content) {
-  appendMarkdown(content, match.id, word, match.definitionFiles[0]);
-  let line = lineText;
-  if (match.declaration === false && match.previewDeclaration === true) {
-    const results = await searchUtils.searchFiles(match.definitionFormat.replace("NAME", word), match.definitionFiles, 0, 1);
-    if (results && results.length > 0) {
-      line = results[0].text;
-    }
-  }
-  if (match.previewDeclaration === true) {
-    const split = line.split('(');
-    if (split.length > 1 && split[1].length > 1) {
-      appendBodyWithLabel(content, "params", split[1].substring(0, split[1].indexOf(')')), true);
-    }
-    if (split.length > 2 && split[2].length > 1) {
-      appendBodyWithLabel(content, "returns", split[2].substring(0, split[2].indexOf(')')), split[1].length === 1);
-    }
-  }
-}
-
-async function buildEnumHoverText(word, match, content) {
-  appendMarkdown(content, match.id, match.definitionFormat.replace("NAME", word), match.definitionFiles[0]);
-  if (!match.declaration && match.previewDeclaration) {
-    const pattern = match.definitionFormat.replace("NAME", word);
-    const results = await searchUtils.searchFiles(pattern, match.definitionFiles, 0, 1, searchUtils.textResult.remaining);
-    if (results && results.length > 0) {
-      results[0].text = results[0].text.replace("inputtype=", "Input type: ");
-      results[0].text = results[0].text.replace("outputtype=", "Output type: ");
-      appendBodyUntilEmptyLine(content, results[0].text, true, 1, "val");
+      appendBody(`input parameter (${lineText.substring(0, lineText.indexOf(word) + word.length)})`, content);
     }
   }
 }
@@ -128,61 +64,90 @@ function buildCommandHoverText(word, match, content) {
   if (match.declaration || !command) {
     return;
   }
-  appendMarkdown(content, match.id, `${word} (${command.type})`, "rs2");
-  if (command.description.length > 0) {
-    appendBodyWithLabel(content, "desc", command.description, true);
-  }
-  if (command.paramsText.length > 0) {
-    appendBodyWithLabel(content, "params", command.paramsText, command.description === '');
-  }
-  if (command.returns.length > 0) {
-    appendBodyWithLabel(content, "returns", command.returns, command.paramsText === '');
-  }
+  appendTitle(`${word} (${command.value})`, match, content);
+  appendSignature(command, content);
 }
 
-async function buildDefaultHoverText(word, match, content) {
-  appendMarkdown(content, match.id, match.definitionFormat.replace("NAME", word), match.definitionFiles[0]);
-  if (!match.declaration && match.previewDeclaration) {
-    const pattern = match.definitionFormat.replace("NAME", word);
-    const results = await searchUtils.searchFiles(pattern, match.definitionFiles, 0, 1, searchUtils.textResult.remaining);
-    if (results && results.length > 0) {
-      appendBodyUntilEmptyLine(content, results[0].text, true, 1);
-    }
+async function buildSignatureHoverText(word, match, uri, content) {
+  const identifier = await getIdentifier(word, match, uri);
+  appendTitle(word, match, content);
+  if (identifier) {
+    appendSignature(identifier, content);
   }
 }
 
-function appendMarkdown(content, type, text, icon) {
-  icon = icon || "rs2";
-  content.appendMarkdown(`<img src="${icon}.png">&ensp;<b>${type.toUpperCase()}</b>&ensp;${text}`);
-}
-
-function appendLineBreak(content) {
-  content.appendMarkdown('\n\n---');
-}
-
-function appendBodyWithLabel(content, label, text, addLineBreak) {
-  appendMarkdownBody(content, `<b>${label}:</b> <i>${text}</i>`, addLineBreak);
-}
-
-function appendMarkdownBody(content, body, addLineBreak) {
-  if (addLineBreak) {
-    appendLineBreak(content);
+async function buildBlockHoverText(word, match, uri, content) {
+  const identifier = await getIdentifier(word, match, uri);
+  if (identifier) {
+    const typeOverride = (match.id === matchType.GLOBAL_VAR.id) ? identifier.value : null; // differentiate global var type
+    appendTitle(word, match, content, typeOverride); 
+    appendBlock(identifier, content);
+  } else {
+    appendTitle(word, match, content);
   }
-  content.appendMarkdown(`\n\n${body}`);
 }
 
-function appendBodyUntilEmptyLine(content, text, addLineBreak, startIndex, terminatingText) {
+async function buildValueHoverText(word, match, uri, content) {
+  const identifier = await getIdentifier(word, match, uri);
+  appendTitle(word, match, content); 
+  if (identifier) {
+    appendValue(identifier, content);
+  }
+}
+
+function appendSignature(identifier, content) {
+  if (identifier.description.length > 0) {
+    appendBodyWithLabel(identifier.description, "desc", content);
+  }
+  if (identifier.paramsText.length > 0) {
+    appendBodyWithLabel(identifier.paramsText, "params", content);
+  }
+  if (identifier.returns.length > 0) {
+    appendBodyWithLabel(identifier.returns, "returns", content);
+  }
+}
+
+function appendBlock(identifier, content, terminatingText) {
   terminatingText = terminatingText || '123';
-  addLineBreak = addLineBreak || false;
-  startIndex = startIndex || 0;
-  const lines = stringUtils.getLines(text);
+  const startIndex = 1;
+  const lines = stringUtils.getLines(identifier.block);
   if (lines.length > startIndex) {
-    if (addLineBreak) appendLineBreak(content);
     for (let i = startIndex; i < lines.length; i++) {
-      if (!/\S/.test(lines[i]) || lines[i].startsWith("//") || lines[i].startsWith(terminatingText)) break;
-      appendMarkdownBody(content, lines[i]);
+      if (!/\S/.test(lines[i]) || lines[i].startsWith(terminatingText)) break;
+      appendBody(lines[i], content);
     }
   }
+}
+
+function appendValue(identifier, content) {
+  if (identifier.value.length > 0) {
+    appendBodyWithLabel(identifier.value, "value", content);
+  }
+}
+
+function appendTitle(text, match, content, typeOverride) {
+  if (typeOverride) {
+    content.appendMarkdown(`<img src="${typeOverride}.png">&ensp;<b>${typeOverride.toUpperCase()}</b>&ensp;${text}`);
+  } else {
+    content.appendMarkdown(`<img src="${match.definitionFiles[0]}.png">&ensp;<b>${match.id.toUpperCase()}</b>&ensp;${text}`);
+  }
+}
+
+function appendBody(text, content) {
+  if (!content.value.includes('---')) {
+    content.appendMarkdown('\n\n---');
+  }
+  content.appendMarkdown(`\n\n${text}`);
+}
+
+function appendBodyWithLabel(text, label, content) {
+  appendBody(`<b>${label}:</b> <i>${text}</i>`, content);
+}
+
+async function getIdentifier(word, match, uri) {
+  return (match.declaration) ? 
+    await identifierSvc.get(word, match, uri) : 
+    await identifierSvc.get(word, match);
 }
 
 module.exports = hoverProvider;

--- a/client/resource/identifierSvc.js
+++ b/client/resource/identifierSvc.js
@@ -1,0 +1,106 @@
+const bodyFormat = require('../enum/BodyFormat');
+const matchType = require('../enum/MatchType');
+const stringUtils = require('../utils/stringUtils');
+const search = require('../utils/searchUtils');
+
+async function get(word, match, fileUri) {
+  // todo: implement caching for declarations to avoid excessive duplicate searching
+  const result = await search.findDefinition(word, match, fileUri);
+  if (!result) {
+    return null;
+  }
+  return parseDefinitionResult(word, match, result.text, result.location);
+}
+
+function parseDefinitionResult(word, match, text, location) {
+  switch(match.id) {
+    case matchType.CONSTANT.id: return parseConstant(word, text, location); 
+    case matchType.GLOBAL_VAR.id: return parseGlobalVar(word, text, location); 
+    case matchType.ENUM.id: return parseEnum(word, text, location);
+    default: return parseDefault(word, match, text, location);
+  }
+}
+
+function parseConstant(word, text, location) {
+  const split = text.split('=');
+  const value = (split.length === 2) ? split[1].trim() : null;
+  return build(word, location, null, null, null, value, null);
+}
+
+function parseGlobalVar(word, text, location) {
+  const fileType = location.uri.path.split(/[#?]/)[0].split('.').pop().trim() || 'varp';
+  return build(word, location, null, null, null, fileType, text);
+}
+
+function parseEnum(word, text, location) {
+  text = text.replace("inputtype=", "<b>input: </b>");
+  text = text.replace("outputtype=", "<b>output: </b>");
+  return build(word, location, null, null, null, null, text);
+}
+
+function parseDefault(word, match, text, location) {
+  const identifier = build(word, location, null, null, null, null, null);
+  if (match.declarationBodyFormat === bodyFormat.SIGNATURE || match.referenceBodyFormat === bodyFormat.SIGNATURE) {
+    const { params, returns } = parseSignature(stringUtils.getLineText(text));
+    identifier.params = params;
+    identifier.paramsText = buildParamsText(params);
+    identifier.returns = returns;
+    if (match.id === matchType.QUEUE.id) {
+      identifier.params.unshift({}, {}); // queue(name, delay, ...) => custom params start at index 2
+    }
+  }
+  if (match.declarationBodyFormat === bodyFormat.BLOCK || match.referenceBodyFormat === bodyFormat.BLOCK) {
+    identifier.block = text;
+  }
+  if (match.declarationBodyFormat === bodyFormat.VALUE || match.referenceBodyFormat === bodyFormat.VALUE) {
+    identifier.value = stringUtils.getLineText(text);
+  }
+  return identifier;
+}
+
+function parseSignature(line) {
+   // Parse input params
+  const params = [];
+  let openingIndex = line.indexOf('(');
+  let closingIndex = line.indexOf(')');
+  if (openingIndex >= 0 && closingIndex >= 0 && ++openingIndex !== closingIndex) {
+    line.substring(openingIndex, closingIndex).split(',').forEach(param => {
+      if (param.startsWith(' ')) param = param.substring(1);
+      const split = param.split(' ');
+      if (split.length === 2) {
+        const match = Object.keys(matchType).filter(key => (matchType[key].types || []).includes(split[0]));
+        params.push({type: split[0], name: split[1], matchType: match.length > 0 ? matchType[match[0]] : matchType.UNKNOWN});
+      }
+    });
+  }
+
+  // Parse response type
+  let returns = '';
+  line = line.substring(closingIndex + 1);
+  openingIndex = line.indexOf('(');
+  closingIndex = line.indexOf(')');
+  if (openingIndex >= 0 && closingIndex >= 0 && ++openingIndex !== closingIndex) {
+    returns = line.substring(openingIndex, closingIndex);
+  }
+
+  return { params: params, returns: returns };
+}
+
+function buildParamsText(params) {
+  return (Array.isArray(params) && params.length > 0) ? params.map(param => `${param.type} ${param.name}`).join(', ') : '';
+}
+
+function build(name, location, params, returns, description, value, block) {
+  return {
+    name: name || '',
+    location: location || null,
+    params: params || [],
+    paramsText: buildParamsText(params) || '',
+    returns: returns || '',
+    description: description || '',
+    value: value || '',
+    block: block || ''
+  }
+}
+
+module.exports = { get, build, parseSignature };

--- a/client/utils/matchUtils.js
+++ b/client/utils/matchUtils.js
@@ -11,8 +11,8 @@ const matchWord = async (document, position) => {
 
   const word = document.getText(wordRange);
   const lineText = document.lineAt(position.line).text;
-  if (lineText.startsWith('//') || word.match(/^\d+.?\d+$/) || word === 'null') {
-    return returnDefault(); // Ignore comments and numbers and null
+  if (lineText.startsWith('//') || word.match(/^\d+.?\d+$/) || word === 'null' || word.length <= 1) {
+    return returnDefault(); // Ignore comments and numbers and null and single character words
   }
 
   const prevWord = getPrevWord(document, wordRange.start);
@@ -51,6 +51,7 @@ const matchWord = async (document, position) => {
   return {
     "word": word,
     "fileType": fileType,
+    "prevChar": prevChar,
     "match": match
   }
 }
@@ -119,7 +120,7 @@ function getCommaMatchType(prevWord) {
   switch (prevWord.substring(0, Math.min(5, prevWord.length))) {
     case "oploc": case "aploc": return reference(matchType.LOC);
     case "ophel": case "opobj": return reference(matchType.OBJ);
-    case "opnpc": case "ai_qu": case "ai_ap": case "ai_ti": return reference(matchType.NPC);
+    case "opnpc": case "ai_qu": case "ai_ap": case "ai_ti": case "ai_op": return reference(matchType.NPC);
   }
   return matchType.UNKNOWN;
 }

--- a/client/utils/matchUtils.js
+++ b/client/utils/matchUtils.js
@@ -18,6 +18,7 @@ const matchWord = async (document, position) => {
   const prevWord = getPrevWord(document, wordRange.start);
   const fileType = document.uri.path.split(/[#?]/)[0].split('.').pop().trim();
   const prevChar = wordRange.start.character > 0 ? lineText.charAt(wordRange.start.character - 1) : '';
+  const nextChar = lineText.charAt(wordRange.end.character);
 
   // try to find a match based on the character proceeding the word
   let match = matchType.UNKNOWN;
@@ -26,7 +27,7 @@ const matchWord = async (document, position) => {
     case ',': match = getCommaMatchType(prevWord); break;
     case '^': match = getConstantMatchType(fileType); break;
     case '%': match = reference(matchType.GLOBAL_VAR); break;
-    case '@': match = reference(matchType.LABEL); break;
+    case '@': match = getAtMatchType(nextChar); break;
     case '~': match = reference(matchType.PROC); break;
     case '$': match = getLocalVarMatchType(prevWord); break;
     case '=': match = getEqualsMatchType(prevWord); break;
@@ -82,6 +83,10 @@ function getLocalVarMatchType(prevWord) {
   const defKeyword = "\\b(int|string|boolean|seq|locshape|component|idk|midi|npc_mode|namedobj|synth|stat|npc_stat|fontmetrics|enum|loc|model|npc|obj|player_uid|spotanim|npc_uid|inv|category|struct|dbrow|interface|dbtable|coord|mesanim|param|queue|weakqueue|timer|softtimer|char|dbcolumn|proc|label)\\b";
   const match = prevWord.match(new RegExp(defKeyword));
   return !match ? reference(matchType.LOCAL_VAR) : declaration(matchType.LOCAL_VAR);
+}
+
+function getAtMatchType(nextChar) {
+  return nextChar !== '@' ? reference(matchType.LABEL) : matchType.UNKNOWN
 }
 
 function getOpenBracketMatchType(fileType) {

--- a/client/utils/matchUtils.js
+++ b/client/utils/matchUtils.js
@@ -1,8 +1,9 @@
 const matchType = require("../enum/MatchType");
 const stringUtils = require("../utils/stringUtils");
 const { commands } = require("../resource/engineCommands");
+const identifierSvc = require('../resource/identifierSvc');
 
-const matchWord = (document, position) => {
+const matchWord = async (document, position) => {
   const wordRange = document.getWordRangeAtPosition(position);
   if (!wordRange) {
     return returnDefault();
@@ -16,11 +17,11 @@ const matchWord = (document, position) => {
 
   const prevWord = getPrevWord(document, wordRange.start);
   const fileType = document.uri.path.split(/[#?]/)[0].split('.').pop().trim();
-  const identifier = wordRange.start.character > 0 ? lineText.charAt(wordRange.start.character - 1) : '';
+  const prevChar = wordRange.start.character > 0 ? lineText.charAt(wordRange.start.character - 1) : '';
 
   // try to find a match based on the character proceeding the word
   let match = matchType.UNKNOWN;
-    switch (identifier) {
+  switch (prevChar) {
     case '[': match = getOpenBracketMatchType(fileType); break;
     case ',': match = getCommaMatchType(prevWord); break;
     case '^': match = getConstantMatchType(fileType); break;
@@ -29,16 +30,17 @@ const matchWord = (document, position) => {
     case '~': match = reference(matchType.PROC); break;
     case '$': match = getLocalVarMatchType(prevWord); break;
     case '=': match = getEqualsMatchType(prevWord); break;
+    case '(': match = getParenthesisMatchType(prevWord); break;
   }
 
   // try to find a match in the list of command names
   if (match.id === matchType.UNKNOWN.id) {
-    match = matchEngineCommand(word, identifier, document);
+    match = matchEngineCommand(word, prevChar, document);
   }
 
   // try to match parameters (possiblities: command, label, proc, or queue parameters)
   if (match.id === matchType.UNKNOWN.id) {
-    match = matchParameter(word, lineText, position.character);
+    match = await matchParameter(word, lineText, position.character);
   }
 
   // return default if no matches found
@@ -49,9 +51,6 @@ const matchWord = (document, position) => {
   return {
     "word": word,
     "fileType": fileType,
-    "prevWord": prevWord,
-    "identifier": identifier,
-    "lineText": lineText,
     "match": match
   }
 }
@@ -135,6 +134,13 @@ function getEqualsMatchType(prevWord) {
   return matchType.UNKNOWN;
 }
 
+function getParenthesisMatchType(prevWord) {
+  switch (prevWord) {
+    case "queue": return reference(matchType.QUEUE);
+  }
+  return matchType.UNKNOWN;
+}
+
 function getConstantMatchType(fileType) {
 	if (fileType === "constant") {
 		return declaration(matchType.CONSTANT);
@@ -142,14 +148,14 @@ function getConstantMatchType(fileType) {
 	return reference(matchType.CONSTANT);
 }
 
-function matchEngineCommand(word, identifier, document) {
-  if (word in commands && identifier !== '[') {
+function matchEngineCommand(word, prevChar, document) {
+  if (word in commands && prevChar !== '[') {
     return (document.uri.path.includes("engine.rs2")) ? declaration(matchType.COMMAND) : reference(matchType.COMMAND);
   }
   return matchType.UNKNOWN;
 }
 
-function matchParameter(word, line, index) {
+async function matchParameter(word, line, index) {
   if (line.substring(index).indexOf(')') === -1) {
     return matchType.UNKNOWN;
   }
@@ -160,32 +166,26 @@ function matchParameter(word, line, index) {
   if (openingIndex < 0 || line.charAt(Math.max(0, openingIndex - 1)) === ']') {
     return matchType.UNKNOWN;
   }
-  const identifier = (line.substring(0, openingIndex).match(/\(?[a-zA-Z_]+$/) || [])[0].replace(/^\(/, '');
+  let name = (line.substring(0, openingIndex).match(/\(?[a-zA-Z_~@]+$/) || [])[0].replace(/^\(/, '');
   const paramIndex = (line.substring(openingIndex).match(/,/g) || []).length;
-  if (identifier === '') {
-    return matchType.UNKNOWN;
-  } else if (identifier === 'queue') {
-    // queue (todo - get queue signature)
-    // name of queue is first param (update identifier to this)
-    // first param could also be a local variable (return UNKNOWN since identifier name is unknown)
-    // 3rd param onwards are custom (2nd param is an int, can ignore it)
-    return matchType.UNKNOWN;
-  } else if (identifier.startsWith('~')) {
-    identifier = identifier.substring(1);
-    // proc (todo - get proc signature) 
-    return matchType.UNKNOWN;
-  } else if (identifier.startsWith('@')) {
-    identifier = identifier.substring(1);
-    // label (todo - get label signature)
-    return matchType.UNKNOWN;
-  } else {
-    const command = commands[identifier];
-    if (!command) {
+
+  let identifier;
+  if (name === 'queue') {
+    if (paramIndex < 2) {
       return matchType.UNKNOWN;
     }
-    const param = command.params[paramIndex];
-    return !param ? matchType.UNKNOWN : param.matchType;
+    identifier = await identifierSvc.get(line.substring(openingIndex + 1, line.indexOf(',')), matchType.QUEUE);
+  } else if (name.startsWith('@')) {
+    identifier = await identifierSvc.get(name.substring(1), matchType.LABEL);
+  } else if (name.startsWith('~')) {
+    identifier = await identifierSvc.get(name.substring(1), matchType.PROC);
+  } else {
+    identifier = commands[name];
   }
+  if (!identifier || !identifier.params || identifier.params.length <= paramIndex) {
+    return matchType.UNKNOWN;
+  }
+  return identifier.params[paramIndex].matchType;
 }
 
 function reference(type) {

--- a/client/utils/searchUtils.js
+++ b/client/utils/searchUtils.js
@@ -12,20 +12,8 @@ const findLocalVar = (fileText, word) => {
 const findDefinition = async function(word, match, fileUri) {
   if (!word || !match) return null;
 
-  let files = [];
-  if (fileUri) {
-    files.push(fileUri);
-  } else {
-    let inclusions;
-    if (match.definitionFile) {
-      inclusions = `**/${match.definitionFile}`;
-    } else {
-      let inclusionsArr = [];
-      match.definitionFiles.forEach(fileType => inclusionsArr.push(`**/*.${fileType}`));
-      inclusions = `{${inclusionsArr.join(",")}}`;
-    }
-    files = await vscode.workspace.findFiles(inclusions) || [];
-  }
+  // If you pass in fileUri, no workspace search is performed 
+  const files = (fileUri) ? [fileUri] : await vscode.workspace.findFiles(getInclusionFiles(match)) || [];
 
   let result;
   const pattern = match.definitionFormat.replace("NAME", word);
@@ -64,4 +52,15 @@ function getPosition(fileText, index, lineIndexOffset) {
   return new vscode.Position(lineNum, lineIndex);
 }
 
-module.exports = { findLocalVar, findDefinition }
+function getInclusionFiles(match) {
+  if (!match) return null;
+  if (match.definitionFile) { // If matchType has a definitionFile defined, only that file will be searched for
+    return `**/${match.definitionFile}`;
+  } else {
+    let inclusionsArr = []; // Otherwise, will serach all file types as defined by matchType.definitionFiles 
+    match.definitionFiles.forEach(fileType => inclusionsArr.push(`**/*.${fileType}`));
+    return `{${inclusionsArr.join(",")}}`;
+  }
+}
+
+module.exports = { findLocalVar, findDefinition, getInclusionFiles };

--- a/client/utils/searchUtils.js
+++ b/client/utils/searchUtils.js
@@ -3,8 +3,6 @@ const fs = require('fs');
 const stringUtils = require('./stringUtils');
 const responseText = require('../enum/responseText');
 
-const exclusions = "{**​/node_modules/**,**/ref/**,**/public/**,**/pack/**,**/3rdparty/**,**/jagex2/**,**/lostcity/**}";
-
 const findLocalVar = (fileText, word) => {
   const varKeyword = "(int|string|boolean|seq|locshape|component|idk|midi|npc_mode|namedobj|synth|stat|npc_stat|fontmetrics|enum|loc|model|npc|obj|player_uid|spotanim|npc_uid|inv|category|struct|dbrow|interface|dbtable|coord|mesanim|param|queue|weakqueue|timer|softtimer|char|dbcolumn|proc|label)\\b";
   const matches = [...fileText.matchAll(new RegExp(`${varKeyword} \\$${word}(,|;|=|\\)| ){1}`, "g"))];
@@ -19,14 +17,14 @@ const findDefinition = async function(word, match, fileUri) {
     files.push(fileUri);
   } else {
     let inclusions;
-    if (match.fileName) {
-      inclusions = `**/${match.fileName}`;
+    if (match.definitionFile) {
+      inclusions = `**/${match.definitionFile}`;
     } else {
       let inclusionsArr = [];
       match.definitionFiles.forEach(fileType => inclusionsArr.push(`**/*.${fileType}`));
       inclusions = `{${inclusionsArr.join(",")}}`;
     }
-    files = await vscode.workspace.findFiles(inclusions, exclusions) || [];
+    files = await vscode.workspace.findFiles(inclusions) || [];
   }
 
   let result;

--- a/client/utils/searchUtils.js
+++ b/client/utils/searchUtils.js
@@ -1,67 +1,69 @@
 const vscode = require('vscode');
 const fs = require('fs');
 const stringUtils = require('./stringUtils');
+const responseText = require('../enum/responseText');
 
-const textResult = {
-  full: "full",
-  remaining: "remaining",
-  line: "line"
-}
+const exclusions = "{**​/node_modules/**,**/ref/**,**/public/**,**/pack/**,**/3rdparty/**,**/jagex2/**,**/lostcity/**}";
 
-const searchFile = async function(pattern, fileName, lineIndexOffset) {
-  const files = await vscode.workspace.findFiles(`**/${fileName}`);
-  const fileText = fs.readFileSync(files[0].path, "utf8");
-  const idx = fileText.indexOf(pattern);
-  if (idx < 0) {
-    return null;
-  }
-  return new vscode.Location(files[0], getPosition(fileText, idx, lineIndexOffset));
-}
-
-const searchFiles = async function(pattern, fileTypes, lineIndexOffset, limit, responseText) {
-  // Might want to switch to findTextInFiles when released https://github.com/microsoft/vscode/issues/59921#issuecomment-2231630101
-  limit = limit || 20;
-  lineIndexOffset = lineIndexOffset || 0;
-  let inclusions = [];
-  fileTypes.forEach(fileType => inclusions.push(`**/*.${fileType}`));
-  const exclude = "{**​/node_modules/**,**/ref/**,**/public/**,**/pack/**,**/3rdparty/**,**/jagex2/**,**/lostcity/**}";
-  const files = await vscode.workspace.findFiles('{' + inclusions.join(",") + '}', exclude);
-
-  let results = [];
-  files.some(fileUri => {
-    const fileText = fs.readFileSync(fileUri.path, "utf8");
-    const idx = fileText.indexOf(pattern);
-    if (idx >= 0) {
-      results.push({
-        "text": getReturnText(responseText, fileText, idx),
-        "location": new vscode.Location(fileUri, getPosition(fileText, idx, lineIndexOffset))
-      });
-      return results.length === limit; // short circuit when result limit is reached
-    }
-  });
-  return results;
-}
-
-const searchLocalVar = (fileText, word) => {
+const findLocalVar = (fileText, word) => {
   const varKeyword = "(int|string|boolean|seq|locshape|component|idk|midi|npc_mode|namedobj|synth|stat|npc_stat|fontmetrics|enum|loc|model|npc|obj|player_uid|spotanim|npc_uid|inv|category|struct|dbrow|interface|dbtable|coord|mesanim|param|queue|weakqueue|timer|softtimer|char|dbcolumn|proc|label)\\b";
   const matches = [...fileText.matchAll(new RegExp(`${varKeyword} \\$${word}(,|;|=|\\)| ){1}`, "g"))];
   return matches[matches.length - 1];
 }
 
-function getReturnText(responseText, fileText, idx) {
-  if (responseText === textResult.full) {
-    return fileText;
-  } else if (responseText === textResult.remaining) {
-    return fileText.substring(idx);
-  } 
-  return stringUtils.getLineText(fileText.substring(idx)); // default = return line
+const findDefinition = async function(word, match, fileUri) {
+  if (!word || !match) return null;
+
+  let files = [];
+  if (fileUri) {
+    files.push(fileUri);
+  } else {
+    let inclusions;
+    if (match.fileName) {
+      inclusions = `**/${match.fileName}`;
+    } else {
+      let inclusionsArr = [];
+      match.definitionFiles.forEach(fileType => inclusionsArr.push(`**/*.${fileType}`));
+      inclusions = `{${inclusionsArr.join(",")}}`;
+    }
+    files = await vscode.workspace.findFiles(inclusions, exclusions) || [];
+  }
+
+  let result;
+  const pattern = match.definitionFormat.replace("NAME", word);
+  files.some(fileUri => {
+    const fileText = fs.readFileSync(fileUri.path, "utf8");
+    const index = fileText.indexOf(pattern);
+    if (index >= 0) {
+      result = buildSearchResult(fileText, index, fileUri, match.responseText, match.definitionFormat.indexOf("NAME"));
+      return true; //short circuit at 1 result
+    }
+  });
+  return result;
+}
+
+function buildSearchResult(fileText, index, fileUri, textType, lineIndexOffset) {
+  return {
+    "text": getReturnText(textType, fileText, index),
+    "location": new vscode.Location(fileUri, getPosition(fileText, index, lineIndexOffset))
+  }
+}
+
+function getReturnText(textType, fileText, index) {
+  switch(textType) {
+    case responseText.FULL: return fileText;
+    case responseText.BLOCK: return stringUtils.getBlockText(fileText.substring(index));
+    case responseText.LINE: return stringUtils.getLineText(fileText.substring(index));
+    default: return '';
+  }
 }
 
 function getPosition(fileText, index, lineIndexOffset) {
   const split = fileText.slice(0, index).split(/\r\n|\r|\n/g);
   const lineNum = split ? split.length - 1 : 0;
   const lineIndex = split[lineNum].length + lineIndexOffset;
+  if (lineIndex < 0) return null;
   return new vscode.Position(lineNum, lineIndex);
 }
 
-module.exports = { textResult, searchFile, searchFiles, searchLocalVar }
+module.exports = { findLocalVar, findDefinition }

--- a/client/utils/stringUtils.js
+++ b/client/utils/stringUtils.js
@@ -1,12 +1,19 @@
-const eolRegex = /\r\n|\r|\n/;
+const endOfLineRegex = /\r\n|\r|\n/;
+// finds first blank line, comment line, line starting with '[', or line starting with "val=" (special case for enums)
+const endOfBlockRegex = /[\r\n|\r|\n](\s*|\/\/.+|\[.+|val=.+)[\r\n|\r|\n]/; 
 
 const getLineText = function(input) {
-  const endOfLine = eolRegex.exec(input);
+  const endOfLine = endOfLineRegex.exec(input);
   return !endOfLine ? input : input.substring(0, endOfLine.index);
 }
 
 const getLines = function(input) {
-  return input.split(eolRegex);
+  return input.split(endOfLineRegex);
+}
+
+const getBlockText = function(input) {
+  const endOfBlock = endOfBlockRegex.exec(input);
+  return !endOfBlock ? input : input.substring(0, endOfBlock.index);
 }
 
 const nthIndexOf = function(input, pattern, n) {
@@ -25,7 +32,7 @@ const truncateMatchingParenthesis = function(str) {
     if (str.charAt(i) === '(') count++;
     if (str.charAt(i) === ')' && --count === 0) truncateIndex = i;
   }
-  return str.substring(truncateIndex + 1);
+  return (truncateIndex > 0) ? str.substring(truncateIndex + 1) : str;
 }
 
-module.exports = { getLineText, getLines, nthIndexOf, truncateMatchingParenthesis };
+module.exports = { getLineText, getLines, getBlockText, nthIndexOf, truncateMatchingParenthesis };


### PR DESCRIPTION
This change sets up nicely to implement caching of identifiers to prevent excessive duplicate searches

also - adds support for matching queue/proc/label parameters to their correct matchType